### PR TITLE
Fixed errors in gen.js

### DIFF
--- a/ChangePropertyActions.jsonld
+++ b/ChangePropertyActions.jsonld
@@ -3,7 +3,10 @@
 		"rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
 		"rdfs": "http://www.w3.org/2000/01/rdf-schema#",
 		"schema": "http://schema.org/",
-		"iot": "http://iotschema.org/"
+		"iot": "http://iotschema.org/",
+		"rdfs:subClassOf": {
+			"@type": "@vocab"
+		}
 	},
 	"@graph": [
 		{
@@ -11,126 +14,126 @@
 			"@type": "rdfs:Class",
 			"rdfs:subClassOf": "iot:ChangePropertyAction",
 			"rdfs:label": "ChangeBinarySwitch",
-			"rdfs:comment": "Specification of an action acting on some property of type <a href=\"http://iotschema.org/BinarySwitch\">BinarySwitch</a>."
+			"rdfs:comment": "Specification of an action acting on some property of type BinarySwitch."
 		},
 		{
 			"@id": "iot:ChangeCountDown",
 			"@type": "rdfs:Class",
 			"rdfs:subClassOf": "iot:ChangePropertyAction",
 			"rdfs:label": "ChangeCountDown",
-			"rdfs:comment": "Specification of an action acting on some property of type <a href=\"http://iotschema.org/CountDown\">CountDown</a>."
+			"rdfs:comment": "Specification of an action acting on some property of type CountDown."
 		},
 		{
 			"@id": "iot:ChangeCurrentColour",
 			"@type": "rdfs:Class",
 			"rdfs:subClassOf": "iot:ChangePropertyAction",
 			"rdfs:label": "ChangeCurrentColour",
-			"rdfs:comment": "Specification of an action acting on some property of type <a href=\"http://iotschema.org/CurrentColour\">CurrentColour</a>."
+			"rdfs:comment": "Specification of an action acting on some property of type CurrentColour."
 		},
 		{
 			"@id": "iot:ChangeCurrentDimmer",
 			"@type": "rdfs:Class",
 			"rdfs:subClassOf": "iot:ChangePropertyAction",
 			"rdfs:label": "ChangeCurrentDimmer",
-			"rdfs:comment": "Specification of an action acting on some property of type <a href=\"http://iotschema.org/CurrentDimmer\">CurrentDimmer</a>."
+			"rdfs:comment": "Specification of an action acting on some property of type CurrentDimmer."
 		},
 		{
 			"@id": "iot:ChangeCurrentLevel",
 			"@type": "rdfs:Class",
 			"rdfs:subClassOf": "iot:ChangePropertyAction",
 			"rdfs:label": "ChangeCurrentLevel",
-			"rdfs:comment": "Specification of an action acting on some property of type <a href=\"http://iotschema.org/CurrentLevel\">CurrentLevel</a>."
+			"rdfs:comment": "Specification of an action acting on some property of type CurrentLevel."
 		},
 		{
 			"@id": "iot:ChangeHumidity",
 			"@type": "rdfs:Class",
 			"rdfs:subClassOf": "iot:ChangePropertyAction",
 			"rdfs:label": "ChangeHumidity",
-			"rdfs:comment": "Specification of an action acting on some property of type <a href=\"http://iotschema.org/Humidity\">Humidity</a>."
+			"rdfs:comment": "Specification of an action acting on some property of type Humidity."
 		},
 		{
 			"@id": "iot:ChangeIlluminance",
 			"@type": "rdfs:Class",
 			"rdfs:subClassOf": "iot:ChangePropertyAction",
 			"rdfs:label": "ChangeIlluminance",
-			"rdfs:comment": "Specification of an action acting on some property of type <a href=\"http://iotschema.org/Illuminance\">Illuminance</a>."
+			"rdfs:comment": "Specification of an action acting on some property of type Illuminance."
 		},
 		{
 			"@id": "iot:ChangeMotionDetectedExt",
 			"@type": "rdfs:Class",
 			"rdfs:subClassOf": "iot:ChangePropertyAction",
 			"rdfs:label": "ChangeMotionDetectedExt",
-			"rdfs:comment": "Specification of an action acting on some property of type <a href=\"http://iotschema.org/MotionDetectedExt\">MotionDetectedExt</a>."
+			"rdfs:comment": "Specification of an action acting on some property of type MotionDetectedExt."
 		},
 		{
 			"@id": "iot:ChangeMotionType",
 			"@type": "rdfs:Class",
 			"rdfs:subClassOf": "iot:ChangePropertyAction",
 			"rdfs:label": "ChangeMotionType",
-			"rdfs:comment": "Specification of an action acting on some property of type <a href=\"http://iotschema.org/MotionType\">MotionType</a>."
+			"rdfs:comment": "Specification of an action acting on some property of type MotionType."
 		},
 		{
 			"@id": "iot:ChangeOperationStatus",
 			"@type": "rdfs:Class",
 			"rdfs:subClassOf": "iot:ChangePropertyAction",
 			"rdfs:label": "ChangeOperationStatus",
-			"rdfs:comment": "Specification of an action acting on some property of type <a href=\"http://iotschema.org/OperationStatus\">OperationStatus</a>."
+			"rdfs:comment": "Specification of an action acting on some property of type OperationStatus."
 		},
 		{
 			"@id": "iot:ChangeRampTime",
 			"@type": "rdfs:Class",
 			"rdfs:subClassOf": "iot:ChangePropertyAction",
 			"rdfs:label": "ChangeRampTime",
-			"rdfs:comment": "Specification of an action acting on some property of type <a href=\"http://iotschema.org/RampTime\">RampTime</a>."
+			"rdfs:comment": "Specification of an action acting on some property of type RampTime."
 		},
 		{
 			"@id": "iot:ChangeRunMode",
 			"@type": "rdfs:Class",
 			"rdfs:subClassOf": "iot:ChangePropertyAction",
 			"rdfs:label": "ChangeRunMode",
-			"rdfs:comment": "Specification of an action acting on some property of type <a href=\"http://iotschema.org/RunMode\">RunMode</a>."
+			"rdfs:comment": "Specification of an action acting on some property of type RunMode."
 		},
 		{
 			"@id": "iot:ChangeSwitchStatus",
 			"@type": "rdfs:Class",
 			"rdfs:subClassOf": "iot:ChangePropertyAction",
 			"rdfs:label": "ChangeSwitchStatus",
-			"rdfs:comment": "Specification of an action acting on some property of type <a href=\"http://iotschema.org/SwitchStatus\">SwitchStatus</a>."
+			"rdfs:comment": "Specification of an action acting on some property of type SwitchStatus."
 		},
 		{
 			"@id": "iot:ChangeTargetHumidity",
 			"@type": "rdfs:Class",
 			"rdfs:subClassOf": "iot:ChangePropertyAction",
 			"rdfs:label": "ChangeTargetHumidity",
-			"rdfs:comment": "Specification of an action acting on some property of type <a href=\"http://iotschema.org/TargetHumidity\">TargetHumidity</a>."
+			"rdfs:comment": "Specification of an action acting on some property of type TargetHumidity."
 		},
 		{
 			"@id": "iot:ChangeTargetTemperature",
 			"@type": "rdfs:Class",
 			"rdfs:subClassOf": "iot:ChangePropertyAction",
 			"rdfs:label": "ChangeTargetTemperature",
-			"rdfs:comment": "Specification of an action acting on some property of type <a href=\"http://iotschema.org/TargetTemperature\">TargetTemperature</a>."
+			"rdfs:comment": "Specification of an action acting on some property of type TargetTemperature."
 		},
 		{
 			"@id": "iot:ChangeTemperature",
 			"@type": "rdfs:Class",
 			"rdfs:subClassOf": "iot:ChangePropertyAction",
 			"rdfs:label": "ChangeTemperature",
-			"rdfs:comment": "Specification of an action acting on some property of type <a href=\"http://iotschema.org/Temperature\">Temperature</a>."
+			"rdfs:comment": "Specification of an action acting on some property of type Temperature."
 		},
 		{
 			"@id": "iot:ChangeTransitionTime",
 			"@type": "rdfs:Class",
 			"rdfs:subClassOf": "iot:ChangePropertyAction",
 			"rdfs:label": "ChangeTransitionTime",
-			"rdfs:comment": "Specification of an action acting on some property of type <a href=\"http://iotschema.org/TransitionTime\">TransitionTime</a>."
+			"rdfs:comment": "Specification of an action acting on some property of type TransitionTime."
 		},
 		{
 			"@id": "iot:ChangeWindStrength",
 			"@type": "rdfs:Class",
 			"rdfs:subClassOf": "iot:ChangePropertyAction",
 			"rdfs:label": "ChangeWindStrength",
-			"rdfs:comment": "Specification of an action acting on some property of type <a href=\"http://iotschema.org/WindStrength\">WindStrength</a>."
+			"rdfs:comment": "Specification of an action acting on some property of type WindStrength."
 		}
 	]
 }

--- a/ChangePropertyActions.jsonld
+++ b/ChangePropertyActions.jsonld
@@ -6,6 +6,9 @@
 		"iot": "http://iotschema.org/",
 		"rdfs:subClassOf": {
 			"@type": "@vocab"
+		},
+		"rdfs:seeAlso": {
+			"@type": "@vocab"
 		}
 	},
 	"@graph": [
@@ -14,126 +17,144 @@
 			"@type": "rdfs:Class",
 			"rdfs:subClassOf": "iot:ChangePropertyAction",
 			"rdfs:label": "ChangeBinarySwitch",
-			"rdfs:comment": "Specification of an action acting on some property of type BinarySwitch."
+			"rdfs:comment": "Specification of an action acting on some property of type BinarySwitch.",
+			"rdfs:seeAlso": "http://iotschema.org/BinarySwitch"
 		},
 		{
 			"@id": "iot:ChangeCountDown",
 			"@type": "rdfs:Class",
 			"rdfs:subClassOf": "iot:ChangePropertyAction",
 			"rdfs:label": "ChangeCountDown",
-			"rdfs:comment": "Specification of an action acting on some property of type CountDown."
+			"rdfs:comment": "Specification of an action acting on some property of type CountDown.",
+			"rdfs:seeAlso": "http://iotschema.org/CountDown"
 		},
 		{
 			"@id": "iot:ChangeCurrentColour",
 			"@type": "rdfs:Class",
 			"rdfs:subClassOf": "iot:ChangePropertyAction",
 			"rdfs:label": "ChangeCurrentColour",
-			"rdfs:comment": "Specification of an action acting on some property of type CurrentColour."
+			"rdfs:comment": "Specification of an action acting on some property of type CurrentColour.",
+			"rdfs:seeAlso": "http://iotschema.org/CurrentColour"
 		},
 		{
 			"@id": "iot:ChangeCurrentDimmer",
 			"@type": "rdfs:Class",
 			"rdfs:subClassOf": "iot:ChangePropertyAction",
 			"rdfs:label": "ChangeCurrentDimmer",
-			"rdfs:comment": "Specification of an action acting on some property of type CurrentDimmer."
+			"rdfs:comment": "Specification of an action acting on some property of type CurrentDimmer.",
+			"rdfs:seeAlso": "http://iotschema.org/CurrentDimmer"
 		},
 		{
 			"@id": "iot:ChangeCurrentLevel",
 			"@type": "rdfs:Class",
 			"rdfs:subClassOf": "iot:ChangePropertyAction",
 			"rdfs:label": "ChangeCurrentLevel",
-			"rdfs:comment": "Specification of an action acting on some property of type CurrentLevel."
+			"rdfs:comment": "Specification of an action acting on some property of type CurrentLevel.",
+			"rdfs:seeAlso": "http://iotschema.org/CurrentLevel"
 		},
 		{
 			"@id": "iot:ChangeHumidity",
 			"@type": "rdfs:Class",
 			"rdfs:subClassOf": "iot:ChangePropertyAction",
 			"rdfs:label": "ChangeHumidity",
-			"rdfs:comment": "Specification of an action acting on some property of type Humidity."
+			"rdfs:comment": "Specification of an action acting on some property of type Humidity.",
+			"rdfs:seeAlso": "http://iotschema.org/Humidity"
 		},
 		{
 			"@id": "iot:ChangeIlluminance",
 			"@type": "rdfs:Class",
 			"rdfs:subClassOf": "iot:ChangePropertyAction",
 			"rdfs:label": "ChangeIlluminance",
-			"rdfs:comment": "Specification of an action acting on some property of type Illuminance."
+			"rdfs:comment": "Specification of an action acting on some property of type Illuminance.",
+			"rdfs:seeAlso": "http://iotschema.org/Illuminance"
 		},
 		{
 			"@id": "iot:ChangeMotionDetectedExt",
 			"@type": "rdfs:Class",
 			"rdfs:subClassOf": "iot:ChangePropertyAction",
 			"rdfs:label": "ChangeMotionDetectedExt",
-			"rdfs:comment": "Specification of an action acting on some property of type MotionDetectedExt."
+			"rdfs:comment": "Specification of an action acting on some property of type MotionDetectedExt.",
+			"rdfs:seeAlso": "http://iotschema.org/MotionDetectedExt"
 		},
 		{
 			"@id": "iot:ChangeMotionType",
 			"@type": "rdfs:Class",
 			"rdfs:subClassOf": "iot:ChangePropertyAction",
 			"rdfs:label": "ChangeMotionType",
-			"rdfs:comment": "Specification of an action acting on some property of type MotionType."
+			"rdfs:comment": "Specification of an action acting on some property of type MotionType.",
+			"rdfs:seeAlso": "http://iotschema.org/MotionType"
 		},
 		{
 			"@id": "iot:ChangeOperationStatus",
 			"@type": "rdfs:Class",
 			"rdfs:subClassOf": "iot:ChangePropertyAction",
 			"rdfs:label": "ChangeOperationStatus",
-			"rdfs:comment": "Specification of an action acting on some property of type OperationStatus."
+			"rdfs:comment": "Specification of an action acting on some property of type OperationStatus.",
+			"rdfs:seeAlso": "http://iotschema.org/OperationStatus"
 		},
 		{
 			"@id": "iot:ChangeRampTime",
 			"@type": "rdfs:Class",
 			"rdfs:subClassOf": "iot:ChangePropertyAction",
 			"rdfs:label": "ChangeRampTime",
-			"rdfs:comment": "Specification of an action acting on some property of type RampTime."
+			"rdfs:comment": "Specification of an action acting on some property of type RampTime.",
+			"rdfs:seeAlso": "http://iotschema.org/RampTime"
 		},
 		{
 			"@id": "iot:ChangeRunMode",
 			"@type": "rdfs:Class",
 			"rdfs:subClassOf": "iot:ChangePropertyAction",
 			"rdfs:label": "ChangeRunMode",
-			"rdfs:comment": "Specification of an action acting on some property of type RunMode."
+			"rdfs:comment": "Specification of an action acting on some property of type RunMode.",
+			"rdfs:seeAlso": "http://iotschema.org/RunMode"
 		},
 		{
 			"@id": "iot:ChangeSwitchStatus",
 			"@type": "rdfs:Class",
 			"rdfs:subClassOf": "iot:ChangePropertyAction",
 			"rdfs:label": "ChangeSwitchStatus",
-			"rdfs:comment": "Specification of an action acting on some property of type SwitchStatus."
+			"rdfs:comment": "Specification of an action acting on some property of type SwitchStatus.",
+			"rdfs:seeAlso": "http://iotschema.org/SwitchStatus"
 		},
 		{
 			"@id": "iot:ChangeTargetHumidity",
 			"@type": "rdfs:Class",
 			"rdfs:subClassOf": "iot:ChangePropertyAction",
 			"rdfs:label": "ChangeTargetHumidity",
-			"rdfs:comment": "Specification of an action acting on some property of type TargetHumidity."
+			"rdfs:comment": "Specification of an action acting on some property of type TargetHumidity.",
+			"rdfs:seeAlso": "http://iotschema.org/TargetHumidity"
 		},
 		{
 			"@id": "iot:ChangeTargetTemperature",
 			"@type": "rdfs:Class",
 			"rdfs:subClassOf": "iot:ChangePropertyAction",
 			"rdfs:label": "ChangeTargetTemperature",
-			"rdfs:comment": "Specification of an action acting on some property of type TargetTemperature."
+			"rdfs:comment": "Specification of an action acting on some property of type TargetTemperature.",
+			"rdfs:seeAlso": "http://iotschema.org/TargetTemperature"
 		},
 		{
 			"@id": "iot:ChangeTemperature",
 			"@type": "rdfs:Class",
 			"rdfs:subClassOf": "iot:ChangePropertyAction",
 			"rdfs:label": "ChangeTemperature",
-			"rdfs:comment": "Specification of an action acting on some property of type Temperature."
+			"rdfs:comment": "Specification of an action acting on some property of type Temperature.",
+			"rdfs:seeAlso": "http://iotschema.org/Temperature"
 		},
 		{
 			"@id": "iot:ChangeTransitionTime",
 			"@type": "rdfs:Class",
 			"rdfs:subClassOf": "iot:ChangePropertyAction",
 			"rdfs:label": "ChangeTransitionTime",
-			"rdfs:comment": "Specification of an action acting on some property of type TransitionTime."
+			"rdfs:comment": "Specification of an action acting on some property of type TransitionTime.",
+			"rdfs:seeAlso": "http://iotschema.org/TransitionTime"
 		},
 		{
 			"@id": "iot:ChangeWindStrength",
 			"@type": "rdfs:Class",
 			"rdfs:subClassOf": "iot:ChangePropertyAction",
 			"rdfs:label": "ChangeWindStrength",
-			"rdfs:comment": "Specification of an action acting on some property of type WindStrength."
+			"rdfs:comment": "Specification of an action acting on some property of type WindStrength.",
+			"rdfs:seeAlso": "http://iotschema.org/WindStrength"
 		}
 	]
 }

--- a/PropertyChangedEvents.jsonld
+++ b/PropertyChangedEvents.jsonld
@@ -6,6 +6,9 @@
 		"iot": "http://iotschema.org/",
 		"rdfs:subClassOf": {
 			"@type": "@vocab"
+		},
+		"rdfs:seeAlso": {
+			"@type": "@vocab"
 		}
 	},
 	"@graph": [
@@ -14,126 +17,144 @@
 			"@type": "rdfs:Class",
 			"rdfs:subClassOf": "iot:PropertyChangedEvent",
 			"rdfs:label": "BinarySwitchChanged",
-			"rdfs:comment": "Specification of an event occurring when some property of type BinarySwitch changes."
+			"rdfs:comment": "Specification of an event occurring when some property of type BinarySwitch changes.",
+			"rdfs:seeAlso": "http://iotschema.org/BinarySwitch"
 		},
 		{
 			"@id": "iot:CountDownChanged",
 			"@type": "rdfs:Class",
 			"rdfs:subClassOf": "iot:PropertyChangedEvent",
 			"rdfs:label": "CountDownChanged",
-			"rdfs:comment": "Specification of an event occurring when some property of type CountDown changes."
+			"rdfs:comment": "Specification of an event occurring when some property of type CountDown changes.",
+			"rdfs:seeAlso": "http://iotschema.org/CountDown"
 		},
 		{
 			"@id": "iot:CurrentColourChanged",
 			"@type": "rdfs:Class",
 			"rdfs:subClassOf": "iot:PropertyChangedEvent",
 			"rdfs:label": "CurrentColourChanged",
-			"rdfs:comment": "Specification of an event occurring when some property of type CurrentColour changes."
+			"rdfs:comment": "Specification of an event occurring when some property of type CurrentColour changes.",
+			"rdfs:seeAlso": "http://iotschema.org/CurrentColour"
 		},
 		{
 			"@id": "iot:CurrentDimmerChanged",
 			"@type": "rdfs:Class",
 			"rdfs:subClassOf": "iot:PropertyChangedEvent",
 			"rdfs:label": "CurrentDimmerChanged",
-			"rdfs:comment": "Specification of an event occurring when some property of type CurrentDimmer changes."
+			"rdfs:comment": "Specification of an event occurring when some property of type CurrentDimmer changes.",
+			"rdfs:seeAlso": "http://iotschema.org/CurrentDimmer"
 		},
 		{
 			"@id": "iot:CurrentLevelChanged",
 			"@type": "rdfs:Class",
 			"rdfs:subClassOf": "iot:PropertyChangedEvent",
 			"rdfs:label": "CurrentLevelChanged",
-			"rdfs:comment": "Specification of an event occurring when some property of type CurrentLevel changes."
+			"rdfs:comment": "Specification of an event occurring when some property of type CurrentLevel changes.",
+			"rdfs:seeAlso": "http://iotschema.org/CurrentLevel"
 		},
 		{
 			"@id": "iot:HumidityChanged",
 			"@type": "rdfs:Class",
 			"rdfs:subClassOf": "iot:PropertyChangedEvent",
 			"rdfs:label": "HumidityChanged",
-			"rdfs:comment": "Specification of an event occurring when some property of type Humidity changes."
+			"rdfs:comment": "Specification of an event occurring when some property of type Humidity changes.",
+			"rdfs:seeAlso": "http://iotschema.org/Humidity"
 		},
 		{
 			"@id": "iot:IlluminanceChanged",
 			"@type": "rdfs:Class",
 			"rdfs:subClassOf": "iot:PropertyChangedEvent",
 			"rdfs:label": "IlluminanceChanged",
-			"rdfs:comment": "Specification of an event occurring when some property of type Illuminance changes."
+			"rdfs:comment": "Specification of an event occurring when some property of type Illuminance changes.",
+			"rdfs:seeAlso": "http://iotschema.org/Illuminance"
 		},
 		{
 			"@id": "iot:MotionDetectedExtChanged",
 			"@type": "rdfs:Class",
 			"rdfs:subClassOf": "iot:PropertyChangedEvent",
 			"rdfs:label": "MotionDetectedExtChanged",
-			"rdfs:comment": "Specification of an event occurring when some property of type MotionDetectedExt changes."
+			"rdfs:comment": "Specification of an event occurring when some property of type MotionDetectedExt changes.",
+			"rdfs:seeAlso": "http://iotschema.org/MotionDetectedExt"
 		},
 		{
 			"@id": "iot:MotionTypeChanged",
 			"@type": "rdfs:Class",
 			"rdfs:subClassOf": "iot:PropertyChangedEvent",
 			"rdfs:label": "MotionTypeChanged",
-			"rdfs:comment": "Specification of an event occurring when some property of type MotionType changes."
+			"rdfs:comment": "Specification of an event occurring when some property of type MotionType changes.",
+			"rdfs:seeAlso": "http://iotschema.org/MotionType"
 		},
 		{
 			"@id": "iot:OperationStatusChanged",
 			"@type": "rdfs:Class",
 			"rdfs:subClassOf": "iot:PropertyChangedEvent",
 			"rdfs:label": "OperationStatusChanged",
-			"rdfs:comment": "Specification of an event occurring when some property of type OperationStatus changes."
+			"rdfs:comment": "Specification of an event occurring when some property of type OperationStatus changes.",
+			"rdfs:seeAlso": "http://iotschema.org/OperationStatus"
 		},
 		{
 			"@id": "iot:RampTimeChanged",
 			"@type": "rdfs:Class",
 			"rdfs:subClassOf": "iot:PropertyChangedEvent",
 			"rdfs:label": "RampTimeChanged",
-			"rdfs:comment": "Specification of an event occurring when some property of type RampTime changes."
+			"rdfs:comment": "Specification of an event occurring when some property of type RampTime changes.",
+			"rdfs:seeAlso": "http://iotschema.org/RampTime"
 		},
 		{
 			"@id": "iot:RunModeChanged",
 			"@type": "rdfs:Class",
 			"rdfs:subClassOf": "iot:PropertyChangedEvent",
 			"rdfs:label": "RunModeChanged",
-			"rdfs:comment": "Specification of an event occurring when some property of type RunMode changes."
+			"rdfs:comment": "Specification of an event occurring when some property of type RunMode changes.",
+			"rdfs:seeAlso": "http://iotschema.org/RunMode"
 		},
 		{
 			"@id": "iot:SwitchStatusChanged",
 			"@type": "rdfs:Class",
 			"rdfs:subClassOf": "iot:PropertyChangedEvent",
 			"rdfs:label": "SwitchStatusChanged",
-			"rdfs:comment": "Specification of an event occurring when some property of type SwitchStatus changes."
+			"rdfs:comment": "Specification of an event occurring when some property of type SwitchStatus changes.",
+			"rdfs:seeAlso": "http://iotschema.org/SwitchStatus"
 		},
 		{
 			"@id": "iot:TargetHumidityChanged",
 			"@type": "rdfs:Class",
 			"rdfs:subClassOf": "iot:PropertyChangedEvent",
 			"rdfs:label": "TargetHumidityChanged",
-			"rdfs:comment": "Specification of an event occurring when some property of type TargetHumidity changes."
+			"rdfs:comment": "Specification of an event occurring when some property of type TargetHumidity changes.",
+			"rdfs:seeAlso": "http://iotschema.org/TargetHumidity"
 		},
 		{
 			"@id": "iot:TargetTemperatureChanged",
 			"@type": "rdfs:Class",
 			"rdfs:subClassOf": "iot:PropertyChangedEvent",
 			"rdfs:label": "TargetTemperatureChanged",
-			"rdfs:comment": "Specification of an event occurring when some property of type TargetTemperature changes."
+			"rdfs:comment": "Specification of an event occurring when some property of type TargetTemperature changes.",
+			"rdfs:seeAlso": "http://iotschema.org/TargetTemperature"
 		},
 		{
 			"@id": "iot:TemperatureChanged",
 			"@type": "rdfs:Class",
 			"rdfs:subClassOf": "iot:PropertyChangedEvent",
 			"rdfs:label": "TemperatureChanged",
-			"rdfs:comment": "Specification of an event occurring when some property of type Temperature changes."
+			"rdfs:comment": "Specification of an event occurring when some property of type Temperature changes.",
+			"rdfs:seeAlso": "http://iotschema.org/Temperature"
 		},
 		{
 			"@id": "iot:TransitionTimeChanged",
 			"@type": "rdfs:Class",
 			"rdfs:subClassOf": "iot:PropertyChangedEvent",
 			"rdfs:label": "TransitionTimeChanged",
-			"rdfs:comment": "Specification of an event occurring when some property of type TransitionTime changes."
+			"rdfs:comment": "Specification of an event occurring when some property of type TransitionTime changes.",
+			"rdfs:seeAlso": "http://iotschema.org/TransitionTime"
 		},
 		{
 			"@id": "iot:WindStrengthChanged",
 			"@type": "rdfs:Class",
 			"rdfs:subClassOf": "iot:PropertyChangedEvent",
 			"rdfs:label": "WindStrengthChanged",
-			"rdfs:comment": "Specification of an event occurring when some property of type WindStrength changes."
+			"rdfs:comment": "Specification of an event occurring when some property of type WindStrength changes.",
+			"rdfs:seeAlso": "http://iotschema.org/WindStrength"
 		}
 	]
 }

--- a/PropertyChangedEvents.jsonld
+++ b/PropertyChangedEvents.jsonld
@@ -3,7 +3,10 @@
 		"rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
 		"rdfs": "http://www.w3.org/2000/01/rdf-schema#",
 		"schema": "http://schema.org/",
-		"iot": "http://iotschema.org/"
+		"iot": "http://iotschema.org/",
+		"rdfs:subClassOf": {
+			"@type": "@vocab"
+		}
 	},
 	"@graph": [
 		{
@@ -11,126 +14,126 @@
 			"@type": "rdfs:Class",
 			"rdfs:subClassOf": "iot:PropertyChangedEvent",
 			"rdfs:label": "BinarySwitchChanged",
-			"rdfs:comment": "Specification of an event occurring when some property of type <a href=\"http://iotschema.org/BinarySwitch\">BinarySwitch</a> changes."
+			"rdfs:comment": "Specification of an event occurring when some property of type BinarySwitch changes."
 		},
 		{
 			"@id": "iot:CountDownChanged",
 			"@type": "rdfs:Class",
 			"rdfs:subClassOf": "iot:PropertyChangedEvent",
 			"rdfs:label": "CountDownChanged",
-			"rdfs:comment": "Specification of an event occurring when some property of type <a href=\"http://iotschema.org/CountDown\">CountDown</a> changes."
+			"rdfs:comment": "Specification of an event occurring when some property of type CountDown changes."
 		},
 		{
 			"@id": "iot:CurrentColourChanged",
 			"@type": "rdfs:Class",
 			"rdfs:subClassOf": "iot:PropertyChangedEvent",
 			"rdfs:label": "CurrentColourChanged",
-			"rdfs:comment": "Specification of an event occurring when some property of type <a href=\"http://iotschema.org/CurrentColour\">CurrentColour</a> changes."
+			"rdfs:comment": "Specification of an event occurring when some property of type CurrentColour changes."
 		},
 		{
 			"@id": "iot:CurrentDimmerChanged",
 			"@type": "rdfs:Class",
 			"rdfs:subClassOf": "iot:PropertyChangedEvent",
 			"rdfs:label": "CurrentDimmerChanged",
-			"rdfs:comment": "Specification of an event occurring when some property of type <a href=\"http://iotschema.org/CurrentDimmer\">CurrentDimmer</a> changes."
+			"rdfs:comment": "Specification of an event occurring when some property of type CurrentDimmer changes."
 		},
 		{
 			"@id": "iot:CurrentLevelChanged",
 			"@type": "rdfs:Class",
 			"rdfs:subClassOf": "iot:PropertyChangedEvent",
 			"rdfs:label": "CurrentLevelChanged",
-			"rdfs:comment": "Specification of an event occurring when some property of type <a href=\"http://iotschema.org/CurrentLevel\">CurrentLevel</a> changes."
+			"rdfs:comment": "Specification of an event occurring when some property of type CurrentLevel changes."
 		},
 		{
 			"@id": "iot:HumidityChanged",
 			"@type": "rdfs:Class",
 			"rdfs:subClassOf": "iot:PropertyChangedEvent",
 			"rdfs:label": "HumidityChanged",
-			"rdfs:comment": "Specification of an event occurring when some property of type <a href=\"http://iotschema.org/Humidity\">Humidity</a> changes."
+			"rdfs:comment": "Specification of an event occurring when some property of type Humidity changes."
 		},
 		{
 			"@id": "iot:IlluminanceChanged",
 			"@type": "rdfs:Class",
 			"rdfs:subClassOf": "iot:PropertyChangedEvent",
 			"rdfs:label": "IlluminanceChanged",
-			"rdfs:comment": "Specification of an event occurring when some property of type <a href=\"http://iotschema.org/Illuminance\">Illuminance</a> changes."
+			"rdfs:comment": "Specification of an event occurring when some property of type Illuminance changes."
 		},
 		{
 			"@id": "iot:MotionDetectedExtChanged",
 			"@type": "rdfs:Class",
 			"rdfs:subClassOf": "iot:PropertyChangedEvent",
 			"rdfs:label": "MotionDetectedExtChanged",
-			"rdfs:comment": "Specification of an event occurring when some property of type <a href=\"http://iotschema.org/MotionDetectedExt\">MotionDetectedExt</a> changes."
+			"rdfs:comment": "Specification of an event occurring when some property of type MotionDetectedExt changes."
 		},
 		{
 			"@id": "iot:MotionTypeChanged",
 			"@type": "rdfs:Class",
 			"rdfs:subClassOf": "iot:PropertyChangedEvent",
 			"rdfs:label": "MotionTypeChanged",
-			"rdfs:comment": "Specification of an event occurring when some property of type <a href=\"http://iotschema.org/MotionType\">MotionType</a> changes."
+			"rdfs:comment": "Specification of an event occurring when some property of type MotionType changes."
 		},
 		{
 			"@id": "iot:OperationStatusChanged",
 			"@type": "rdfs:Class",
 			"rdfs:subClassOf": "iot:PropertyChangedEvent",
 			"rdfs:label": "OperationStatusChanged",
-			"rdfs:comment": "Specification of an event occurring when some property of type <a href=\"http://iotschema.org/OperationStatus\">OperationStatus</a> changes."
+			"rdfs:comment": "Specification of an event occurring when some property of type OperationStatus changes."
 		},
 		{
 			"@id": "iot:RampTimeChanged",
 			"@type": "rdfs:Class",
 			"rdfs:subClassOf": "iot:PropertyChangedEvent",
 			"rdfs:label": "RampTimeChanged",
-			"rdfs:comment": "Specification of an event occurring when some property of type <a href=\"http://iotschema.org/RampTime\">RampTime</a> changes."
+			"rdfs:comment": "Specification of an event occurring when some property of type RampTime changes."
 		},
 		{
 			"@id": "iot:RunModeChanged",
 			"@type": "rdfs:Class",
 			"rdfs:subClassOf": "iot:PropertyChangedEvent",
 			"rdfs:label": "RunModeChanged",
-			"rdfs:comment": "Specification of an event occurring when some property of type <a href=\"http://iotschema.org/RunMode\">RunMode</a> changes."
+			"rdfs:comment": "Specification of an event occurring when some property of type RunMode changes."
 		},
 		{
 			"@id": "iot:SwitchStatusChanged",
 			"@type": "rdfs:Class",
 			"rdfs:subClassOf": "iot:PropertyChangedEvent",
 			"rdfs:label": "SwitchStatusChanged",
-			"rdfs:comment": "Specification of an event occurring when some property of type <a href=\"http://iotschema.org/SwitchStatus\">SwitchStatus</a> changes."
+			"rdfs:comment": "Specification of an event occurring when some property of type SwitchStatus changes."
 		},
 		{
 			"@id": "iot:TargetHumidityChanged",
 			"@type": "rdfs:Class",
 			"rdfs:subClassOf": "iot:PropertyChangedEvent",
 			"rdfs:label": "TargetHumidityChanged",
-			"rdfs:comment": "Specification of an event occurring when some property of type <a href=\"http://iotschema.org/TargetHumidity\">TargetHumidity</a> changes."
+			"rdfs:comment": "Specification of an event occurring when some property of type TargetHumidity changes."
 		},
 		{
 			"@id": "iot:TargetTemperatureChanged",
 			"@type": "rdfs:Class",
 			"rdfs:subClassOf": "iot:PropertyChangedEvent",
 			"rdfs:label": "TargetTemperatureChanged",
-			"rdfs:comment": "Specification of an event occurring when some property of type <a href=\"http://iotschema.org/TargetTemperature\">TargetTemperature</a> changes."
+			"rdfs:comment": "Specification of an event occurring when some property of type TargetTemperature changes."
 		},
 		{
 			"@id": "iot:TemperatureChanged",
 			"@type": "rdfs:Class",
 			"rdfs:subClassOf": "iot:PropertyChangedEvent",
 			"rdfs:label": "TemperatureChanged",
-			"rdfs:comment": "Specification of an event occurring when some property of type <a href=\"http://iotschema.org/Temperature\">Temperature</a> changes."
+			"rdfs:comment": "Specification of an event occurring when some property of type Temperature changes."
 		},
 		{
 			"@id": "iot:TransitionTimeChanged",
 			"@type": "rdfs:Class",
 			"rdfs:subClassOf": "iot:PropertyChangedEvent",
 			"rdfs:label": "TransitionTimeChanged",
-			"rdfs:comment": "Specification of an event occurring when some property of type <a href=\"http://iotschema.org/TransitionTime\">TransitionTime</a> changes."
+			"rdfs:comment": "Specification of an event occurring when some property of type TransitionTime changes."
 		},
 		{
 			"@id": "iot:WindStrengthChanged",
 			"@type": "rdfs:Class",
 			"rdfs:subClassOf": "iot:PropertyChangedEvent",
 			"rdfs:label": "WindStrengthChanged",
-			"rdfs:comment": "Specification of an event occurring when some property of type <a href=\"http://iotschema.org/WindStrength\">WindStrength</a> changes."
+			"rdfs:comment": "Specification of an event occurring when some property of type WindStrength changes."
 		}
 	]
 }

--- a/tools/gen.js
+++ b/tools/gen.js
@@ -7,7 +7,10 @@ const ctx = {
     'rdf': 'http://www.w3.org/1999/02/22-rdf-syntax-ns#',
     'rdfs': 'http://www.w3.org/2000/01/rdf-schema#',
     'schema': 'http://schema.org/',
-    'iot': 'http://iotschema.org/'
+    'iot': 'http://iotschema.org/',
+    'rdfs:subClassOf': {
+        '@type': '@vocab'
+    }
 };
 
 const actions = [];
@@ -32,7 +35,8 @@ function getAnchoredName(node) {
 function generate(node) {
     if (isProperty(node)) {
         let name = getLocalName(node);
-        let anchored = getAnchoredName(node);
+        let anchored = name;
+        //let anchored = getAnchoredName(node);
         
         let a = {
             '@id': 'iot:Change' + name,

--- a/tools/gen.js
+++ b/tools/gen.js
@@ -10,6 +10,9 @@ const ctx = {
     'iot': 'http://iotschema.org/',
     'rdfs:subClassOf': {
         '@type': '@vocab'
+    },
+    'rdfs:seeAlso': {
+        '@type': '@vocab'
     }
 };
 
@@ -28,22 +31,17 @@ function getLocalName(node) {
     return node['@id'].replace('http://iotschema.org/', '');
 }
 
-function getAnchoredName(node) {
-    return '<a href="' + node['@id'] + '">' + getLocalName(node) + '</a>';
-}
-
 function generate(node) {
     if (isProperty(node)) {
         let name = getLocalName(node);
-        let anchored = name;
-        //let anchored = getAnchoredName(node);
         
         let a = {
             '@id': 'iot:Change' + name,
             '@type': 'rdfs:Class',
             'rdfs:subClassOf': 'iot:ChangePropertyAction',
             'rdfs:label': 'Change' + name,
-            'rdfs:comment': 'Specification of an action acting on some property of type ' + anchored + '.'
+            'rdfs:comment': 'Specification of an action acting on some property of type ' + name + '.',
+            'rdfs:seeAlso': node['@id']
         }
         actions.push(a);
         
@@ -52,7 +50,8 @@ function generate(node) {
             '@type': 'rdfs:Class',
             'rdfs:subClassOf': 'iot:PropertyChangedEvent',
             'rdfs:label': name + 'Changed',
-            'rdfs:comment': 'Specification of an event occurring when some property of type ' + anchored + ' changes.'
+            'rdfs:comment': 'Specification of an event occurring when some property of type ' + name + ' changes.',
+            'rdfs:seeAlso': node['@id']
         }
         events.push(e);
     }


### PR DESCRIPTION
Changes are now online on [iotschema.org](http://iotschema.org/docs/full.html). Few fixes were needed for a proper rendering of the term definitions.