### PR TITLE
Short names for units

### DIFF
--- a/capability.jsonld
+++ b/capability.jsonld
@@ -257,8 +257,7 @@
 		"@id": "iot:AmbientAir",
 		"@type": "rdfs:Class",
 		"rdfs:subClassOf": { "@id": "iot:Capability" },
-		"rdfs:comment": "A capability to monitor gases in ambient air. Ambient air refers to any unconfined portion of the
-	atmosphere or outdoor air.",
+		"rdfs:comment": "A capability to monitor gases in ambient air. Ambient air refers to any unconfined portion of the atmosphere or outdoor air.",
 		"rdfs:label": "AmbientAir",
 		"iot:domain": [
 				{"@id": "iot:Building"},

--- a/core.jsonld
+++ b/core.jsonld
@@ -158,11 +158,8 @@
       "@type": "rdfs:Class",
       "rdfs:comment": "Equipment subclass of FeatureOfInterest",
       "rdfs:label": "Equipment",
-<<<<<<< HEAD
 	  "dct:source": "https://project-haystack.org/tag/equip",
-=======
-	  "dct:source": "https://project-haystack.org/tag/equip"
->>>>>>> 8e5c068641ba925ffffd56c37b7944817cde62f8
+	  "dct:source": "https://project-haystack.org/tag/equip",
       "rdfs:subClassOf": {
         "@id": "iot:FeatureOfInterest"
       } 

--- a/unit.jsonld
+++ b/unit.jsonld
@@ -23,7 +23,7 @@
 		"@id": "iot:Celsius",
 		"@type": "iot:TemperatureUnit",
 		"rdfs:comment": "unit of the temperature of which the scale is defined by two fixe-points, the temperatures of freezing and boiling point of water at normal pressure (air pressure of 1 013,25 hPa)",
-		"rdfs:label": "Celsius",
+		"rdfs:label": "cel",
 		"iot:reference": "0112/2///62720#UAA033#001",
 		"dct:source": "http://data.nasa.gov/qudt/owl/unit#DegreeCelsius"
 	},
@@ -31,7 +31,7 @@
 		"@id": "iot:Kelvin",
 		"@type": "iot:TemperatureUnit",
 		"rdfs:comment": "unit of thermodynamic temperature is the fraction 1/273,16 of the thermodynamic temperature of the triple point of water",
-		"rdfs:label": "Kelvin",
+		"rdfs:label": "K",
 		"iot:reference" : "0112/2///62720#UAA185#001",
 		"dct:source": "http://data.nasa.gov/qudt/owl/unit#Kelvin"
     },
@@ -39,7 +39,7 @@
 		"@id": "iot:Fahrenheit",
 		"@type": "iot:TemperatureUnit",
 		"rdfs:comment": "unit of temperature according to the temperature of the freezing and boiling point of water (32 °F and 212 °F)",
-		"rdfs:label": "Fahrenheit",
+		"rdfs:label": "degf",
 		"iot:reference" : "0112/2///62720#UAA039#001",
 		"dct:source": "http://data.nasa.gov/qudt/owl/unit#DegreeFahrenheit"
     },
@@ -56,7 +56,7 @@
 		"@id": "iot:Second",
 		"@type": "iot:TimeUnitType",
 		"rdfs:comment": "Second Time Unit",
-		"rdfs:label": "Second",
+		"rdfs:label": "s",
 	    "iot:reference" : "0112/2///62720#UAA972#001",
 	    "dct:source": "http://data.nasa.gov/qudt/owl/unit#SecondTime"
 	},
@@ -64,7 +64,7 @@
 		"@id": "iot:Minute",
 		"@type": "iot:TimeUnitType",
 		"rdfs:comment": "Minute Time Unit",
-		"rdfs:label": "Minute",
+		"rdfs:label": "min",
 	    "iot:reference" : "0112/2///62720#UAA842#001",
 	    "dct:source": "http://data.nasa.gov/qudt/owl/unit#MinuteTime"
 	},
@@ -72,7 +72,7 @@
 		"@id": "iot:Hour",
 		"@type": "iot:TimeUnitType",
 		"rdfs:comment": "Hour Time Unit",
-		"rdfs:label": "Hour",
+		"rdfs:label": "h",
 	    "iot:reference" : "0112/2///62720#UAA407#001",
 	    "dct:source": "http://data.nasa.gov/qudt/owl/unit#Hour"
 	},
@@ -80,7 +80,7 @@
 		"@id": "iot:Lux",
 		"@type": "iot:IlluminanceUnit",
 		"rdfs:comment": "Illuminance Unit",
-		"rdfs:label": "Lux",
+		"rdfs:label": "lm/m2",
 	    "iot:reference" : "0112/2///62720#UAA723#001",
 	    "dct:source": "http://qudt.org/vocab/unit#Lux"
 	},
@@ -98,7 +98,7 @@
 		"@type": "iot:LevelUnit",
 		"@type": "iot:GasInAirConcentrationUnit",
 		"rdfs:comment": "Unit of measurement for level or concentration.",
-		"rdfs:label": "Percent",
+		"rdfs:label": "%",
 	    "iot:reference" : "0112/2///62720#UAA000#001",
 	    "dct:source": "http://qudt.org/vocab/unit#Percent"
 	},
@@ -106,14 +106,14 @@
 		"@id": "iot:Millimetre",
 		"@type": "iot:LevelUnit",
 		"rdfs:comment": "Unit of measurement in millimetre",
-		"rdfs:label": "Millimetre",
+		"rdfs:label": "mm",
 	    "iot:reference" : "0112/2///62720#UAA862#001"
 	},
     {
 		"@id": "iot:Centimetre",
 		"@type": "iot:LevelUnit",
 		"rdfs:comment": "Unit of measurement in centimetre",
-		"rdfs:label": "Centimetre",
+		"rdfs:label": "cm",
 	    "iot:reference" : "0112/2///62720#UAA375#001",
 	    "dct:source": "http://qudt.org/vocab/unit#Centimeter"
 	},
@@ -130,7 +130,7 @@
 		"@id": "iot:KilogramPerCubicMeter",
 		"@type": "iot:DensityUnit",
 		"rdfs:comment": "unit of the density of liquid",
-		"rdfs:label": "KilogramPerCubicMeter",
+		"rdfs:label": "kg/m3",
 		"iot:reference": "0112/2///62720#UAA619#001",
 		"dct:source": "http://data.nasa.gov/qudt/owl/unit#KilogramPerCubicMeter"
 	},
@@ -147,7 +147,7 @@
 		"@id": "iot:Pascal",
 		"@type": "iot:PressureUnit",
 		"rdfs:comment": "The pascal (symbol: Pa) is the SI derived unit of pressure used to quantify internal pressure, stress, Young's modulus and ultimate tensile strength. It is defined as one newton per square metre.",
-		"rdfs:label": "Pascal",
+		"rdfs:label": "Pa",
 		"iot:reference": "0112/2///62720#UAA258#001",
 		"dct:source": "http://data.nasa.gov/qudt/owl/unit#Pascal"
 	},
@@ -155,7 +155,7 @@
 		"@id": "iot:Bar",
 		"@type": "iot:PressureUnit",
 		"rdfs:comment": "The bar (symbol: bar) is a metric unit of pressure, but is not approved as part of the International System of Units (SI).",
-		"rdfs:label": "Bar",
+		"rdfs:label": "bar",
 		"iot:reference": "0112/2///62720#UAA323#001",
 		"dct:source": "http://data.nasa.gov/qudt/owl/unit#Bar"
 	},
@@ -172,21 +172,21 @@
 		"@id": "iot:GallonsPerMinute",
 		"@type": "iot:FlowRateUnit",
 		"rdfs:comment": "unit of measurement of liquid flow rate",
-		"rdfs:label": "GallonsPerMinute",
+		"rdfs:label": "gal/min",
 		"dct:source":"http://data.nasa.gov/qudt/owl/unit#GallonUSPerMinute"
 	},
     {
 		"@id": "iot:LitrePerMinute",
 		"@type": "iot:FlowRateUnit",
 		"rdfs:comment": "Unit of measurement of flow rate of a substance",
-		"rdfs:label": "LitrePerMinute",
+		"rdfs:label": "L/min",
 		"iot:reference": "0112/2///62720#UAA659#001"
 	},
 	{
 		"@id": "iot:Decibel",
 		"@type": "iot:SoundPressureUnit",
 		"rdfs:comment": "Sound Pressure Unit",
-		"rdfs:label": "SoundPressureUnit",
+		"rdfs:label": "dB",
 		"iot:reference" : "0112/2///62720#UAA409#001",
 		"dct:source": "http://qudt.org/vocab/unit#Decibel"
 	},
@@ -203,7 +203,7 @@
 		"@id": "iot:PartsPerMillion",
 		"@type": "iot:GasInAirConcentrationUnit",
 		"rdfs:comment": "The unit of concentration of gas in the air, e.g., concentration of carbon dioxide (CO2) in ambient air.",
-		"rdfs:label": "parts-per-million"
+		"rdfs:label": "ppm"
 	},	
 	{
 		"@id": "iot:ApparentPowerUnit",
@@ -218,28 +218,28 @@
 		"@id": "iot:VoltAmpere",
 		"@type": "iot:ApparentPowerUnit",
 		"rdfs:comment": "The unit of the apparent power.",
-		"rdfs:label": "volt-ampere",
+		"rdfs:label": "V.A",
 		"iot:reference": "0112/2///62720#UAA298#001"
 	},
 	{
 		"@id": "iot:KiloVoltAmpere",
 		"@type": "iot:ApparentPowerUnit",
 		"rdfs:comment": "The unit of the apparent power, expressed in kilo (one thousand) as a decimal unit prefix.",
-		"rdfs:label": "kilovolt-ampere",
+		"rdfs:label": "kV·A",
 		"iot:reference": "0112/2///62720#UAA581#001"
 	},
 	{
 		"@id": "iot:MegaVoltAmpere",
 		"@type": "iot:ApparentPowerUnit",
 		"rdfs:comment": "The unit of the apparent power, expressed in mega (one million) as a decimal unit prefix.",
-		"rdfs:label": "megavolt-ampere",
+		"rdfs:label": "MV.A",
 		"iot:reference": "0112/2///62720#UAA222#001"
 	},
 	{
 		"@id": "iot:GigaVoltAmpere",
 		"@type": "iot:ApparentPowerUnit",
 		"rdfs:comment": "The unit of the apparent power, expressed in giga (one billion) as a decimal unit prefix.",
-		"rdfs:label": "gigavolt-ampere", 
+		"rdfs:label": "GV.A", 
 		"iot:reference": "0112/2///62720#UAB534#001"
 	},
 	{
@@ -255,7 +255,7 @@
 		"@id": "iot:Watt",
 		"@type": "iot:ActivePowerUnit",
 		"rdfs:comment": "The unit of the active power.",
-		"rdfs:label": "watt",
+		"rdfs:label": "W",
 		"dct:source": "http://www.qudt.org/qudt/owl/1.0.0/unit/Instances.html#Watt",
 		"iot:reference": "0112/2///62720#UAA306#001"
 	},
@@ -263,21 +263,21 @@
 		"@id": "iot:KiloWatt",
 		"@type": "iot:ActivePowerUnit",
 		"rdfs:comment": "The unit of the active power, expressed in kilo (one thousand) as a decimal unit prefix.",
-		"rdfs:label": "kilowatt",
+		"rdfs:label": "kW",
 		"iot:reference": "0112/2///62720#UAA583#001"
 	},
 	{
 		"@id": "iot:MegaWatt",
 		"@type": "iot:ActivePowerUnit",
 		"rdfs:comment": "The unit of the active power, expressed in mega (one million) as a decimal unit prefix.",
-		"rdfs:label": "megawatt",
+		"rdfs:label": "MW",
 		"iot:reference": "0112/2///62720#UAA224#001"
 	},
 	{
 		"@id": "iot:GigaWatt",
 		"@type": "iot:ActivePowerUnit",
 		"rdfs:comment": "The unit of the active power, expressed in giga (one billion) as a decimal unit prefix.",
-		"rdfs:label": "gigawatt",
+		"rdfs:label": "GW",
 		"iot:reference": "0112/2///62720#UAA154#001"
 	},
 	{
@@ -293,28 +293,28 @@
 		"@id": "iot:VoltAmpereReactive",
 		"@type": "iot:ReactivePowerUnit",
 		"rdfs:comment": "The unit of reactive power.",
-		"rdfs:label": "volt-ampere-reactive",
+		"rdfs:label": "var",
 		"iot:reference": "0112/2///62720#UAB023#001"
 	},
 	{
 		"@id": "iot:KiloVoltAmpereReactive",
 		"@type": "iot:ReactivePowerUnit",
 		"rdfs:comment": "The unit of reactive power, expressed in kilo (one thousand) as a decimal unit prefix.",
-		"rdfs:label": "kilovolt-ampere-reactive",
+		"rdfs:label": "kvar",
 		"iot:reference": "0112/2///62720#UAB195#001"
 	},
 	{
 		"@id": "iot:MegaVoltAmpereReactive",
 		"@type": "iot:ReactivePowerUnit",
 		"rdfs:comment": "The unit of reactive power, expressed in mega (one million) as a decimal unit prefix.",
-		"rdfs:label": "megavolt-ampere-reactive",
+		"rdfs:label": "Mvar",
 		"iot:reference": "0112/2///62720#UAB199#001"
 	},
 	{
 		"@id": "iot:GigaVoltAmpereReactive",
 		"@type": "iot:ReactivePowerUnit",
 		"rdfs:comment": "The unit of reactive power, expressed in giga (one billion) as a decimal unit prefix.",
-		"rdfs:label": "gigavolt-ampere-reactive"
+		"rdfs:label": "Gvar"
 	},	
 	{
 		"@id": "iot:ElectricCurrentUnit",
@@ -329,70 +329,70 @@
 		"@id": "iot:Ampere",
 		"@type": "iot:ElectricCurrentUnit",
 		"rdfs:comment": "The unit of electric current.",
-		"rdfs:label": "ampere",
+		"rdfs:label": "A",
 		"iot:reference": "0112/2///62720#UAA101#001",
 		"dct:source": "http://www.qudt.org/qudt/owl/1.0.0/unit/Instances.html#Ampere"
 	},
 	{
 		"@id": "iot:FemtoAmpere",
 		"@type": "iot:ElectricCurrentUnit",
-		"rdfs:comment": "The unit of electric current, expressed in a unit prefix meaning "one 0.000000000000001".",
-		"rdfs:label": "femtoampere",
+		"rdfs:comment": "The unit of electric current, expressed in a unit prefix meaning 'one 0.000000000000001'.",
+		"rdfs:label": "fA",
 		"iot:reference": "0112/2///62720#UAB638#001"
 	},
 	{
 		"@id": "iot:PicoAmpere",
 		"@type": "iot:ElectricCurrentUnit",
-		"rdfs:comment": "The unit of electric current, expressed in a unit prefix meaning "one trillionth".",
-		"rdfs:label": "picoampere",
+		"rdfs:comment": "The unit of electric current, expressed in a unit prefix meaning 'one trillionth'.",
+		"rdfs:label": "pA",
 		"iot:reference": "0112/2///62720#UAA928#001"
 	},
 	{
 		"@id": "iot:NanoAmpere",
 		"@type": "iot:ElectricCurrentUnit",
-		"rdfs:comment": "The unit of electric current, expressed in a unit prefix meaning "one billionth".",
-		"rdfs:label": "nanoampere",
+		"rdfs:comment": "The unit of electric current, expressed in a unit prefix meaning 'one billionth'.",
+		"rdfs:label": "nA",
 		"iot:reference": "0112/2///62720#UAA901#001"
 	},
 	{
 		"@id": "iot:MicroAmpere",
 		"@type": "iot:ElectricCurrentUnit",
-		"rdfs:comment": "The unit of electric current, expressed in a unit prefix meaning "one millionth".",
-		"rdfs:label": "microampere",
+		"rdfs:comment": "The unit of electric current, expressed in a unit prefix meaning 'one millionth'.",
+		"rdfs:label": "µA",
 		"iot:reference": "0112/2///62720#UAA057#001"
 	},
 	{
 		"@id": "iot:MilliAmpere",
 		"@type": "iot:ElectricCurrentUnit",
-		"rdfs:comment": "The unit of electric current, expressed in a unit prefix meaning "one thousandth".",
-		"rdfs:label": "milliampere",
+		"rdfs:comment": "The unit of electric current, expressed in a unit prefix meaning 'one thousandth'.",
+		"rdfs:label": "mA",
 		"iot:reference": "0112/2///62720#UAA775#001"
 	},
 	{
 		"@id": "iot:KiloAmpere",
 		"@type": "iot:ElectricCurrentUnit",
-		"rdfs:comment": "The unit of electric current, expressed in a unit prefix meaning "one thousand".",
-		"rdfs:label": "kiloampere",
+		"rdfs:comment": "The unit of electric current, expressed in a unit prefix meaning 'one thousand'.",
+		"rdfs:label": "kA",
 		"iot:reference": "0112/2///62720#UAA557#001"
 	},
 	{
 		"@id": "iot:MegaAmpere",
 		"@type": "iot:ElectricCurrentUnit",
-		"rdfs:comment": "The unit of electric current, expressed in a unit prefix meaning "one million".",
-		"rdfs:label": "megaampere",
+		"rdfs:comment": "The unit of electric current, expressed in a unit prefix meaning 'one million'.",
+		"rdfs:label": "MA",
 		"iot:reference": "0112/2///62720#UAA202#001"
 	},
 	{
 		"@id": "iot:GigaAmpere",
 		"@type": "iot:ElectricCurrentUnit",
-		"rdfs:comment": "The unit of electric current, expressed in a unit prefix meaning "one billion".",
-		"rdfs:label": "gigaampere"
+		"rdfs:comment": "The unit of electric current, expressed in a unit prefix meaning 'one billion'.",
+		"rdfs:label": "GA"
 	},
 	{
 		"@id": "iot:TeraAmpere",
 		"@type": "iot:ElectricCurrentUnit",
-		"rdfs:comment": "The unit of electric current, expressed in a unit prefix meaning "one trillion".",
-		"rdfs:label": "teraampere",
+		"rdfs:comment": "The unit of electric current, expressed in a unit prefix meaning 'one trillion'.",
+		"rdfs:label": "TA",
 		"iot:reference": "0112/2///62720#UAB640#001"
 	},	
 	{
@@ -408,70 +408,70 @@
 		"@id": "iot:Hertz",
 		"@type": "iot:LineFrequencyUnit",
 		"rdfs:comment": "The unit of line frequency.",
-		"rdfs:label": "hertz",
+		"rdfs:label": "Hz",
 		"iot:reference": "0112/2///62720#UAA170#001",
 		"dct:source": "http://www.qudt.org/qudt/owl/1.0.0/unit/Instances.html#Hertz"
 	},
 	{
 		"@id": "iot:Femtohertz",
 		"@type": "iot:LineFrequencyUnit",
-		"rdfs:comment": "The unit of line frequency, expressed in a unit prefix meaning "one 0.000000000000001".",
-		"rdfs:label": "femtohertz"
+		"rdfs:comment": "The unit of line frequency, expressed in a unit prefix meaning 'one 0.000000000000001'.",
+		"rdfs:label": "fHz"
 	},
 	{
 		"@id": "iot:Picohertz",
 		"@type": "iot:LineFrequencyUnit",
-		"rdfs:comment": "The unit of line frequency, expressed in a unit prefix meaning "one trillionth".",
-		"rdfs:label": "picohertz"
+		"rdfs:comment": "The unit of line frequency, expressed in a unit prefix meaning 'one trillionth'.",
+		"rdfs:label": "pHz"
 	},
 	{
 		"@id": "iot:Nanoampere",
 		"@type": "iot:LineFrequencyUnit",
-		"rdfs:comment": "The unit of line frequency, expressed in a unit prefix meaning "one billionth".",
-		"rdfs:label": "nanohertz"
+		"rdfs:comment": "The unit of line frequency, expressed in a unit prefix meaning 'one billionth'.",
+		"rdfs:label": "nHz"
 	},
 	{
 		"@id": "iot:Microhertz",
 		"@type": "iot:LineFrequencyUnit",
-		"rdfs:comment": "The unit of line frequency, expressed in a unit prefix meaning "one millionth".",
-		"rdfs:label": "microhertz"
+		"rdfs:comment": "The unit of line frequency, expressed in a unit prefix meaning 'one millionth'.",
+		"rdfs:label": "µHz"
 	},
 	{
 		"@id": "iot:Millihertz",
 		"@type": "iot:LineFrequencyUnit",
-		"rdfs:comment": "The unit of line frequency, expressed in a unit prefix meaning "one thousandth".",
-		"rdfs:label": "millihertz",
+		"rdfs:comment": "The unit of line frequency, expressed in a unit prefix meaning 'one thousandth'.",
+		"rdfs:label": "mHz",
 		"iot:reference": "0112/2///62720#UAB698#001"
 	},
 	{
 		"@id": "iot:KiloHertz",
 		"@type": "iot:LineFrequencyUnit",
-		"rdfs:comment": "The unit of line frequency, expressed in a unit prefix meaning "one thousand".",
-		"rdfs:label": "kilohertz",
+		"rdfs:comment": "The unit of line frequency, expressed in a unit prefix meaning 'one thousand'.",
+		"rdfs:label": "kHz",
 		"iot:reference": "0112/2///62720#UAA566#001",
 		"dct:source": "http://www.qudt.org/qudt/owl/1.0.0/unit/Instances.html#KiloHertz"
 	},
 	{
 		"@id": "iot:MegaHertz",
 		"@type": "iot:LineFrequencyUnit",
-		"rdfs:comment": "The unit of line frequency, expressed in a unit prefix meaning "one million".",
-		"rdfs:label": "megahertz",
+		"rdfs:comment": "The unit of line frequency, expressed in a unit prefix meaning 'one million'.",
+		"rdfs:label": "MHz",
 		"iot:reference": "0112/2///62720#UAA209#001",
 		"dct:source": "http://www.qudt.org/qudt/owl/1.0.0/unit/Instances.html#MegaHertz"
 	},
 	{
 		"@id": "iot:GigaHertz",
 		"@type": "iot:LineFrequencyUnit",
-		"rdfs:comment": "The unit of line frequency, expressed in a unit prefix meaning "one billion".",
-		"rdfs:label": "gigahertz",
+		"rdfs:comment": "The unit of line frequency, expressed in a unit prefix meaning 'one billion'.",
+		"rdfs:label": "GHz",
 		"iot:reference": "0112/2///62720#UAA150#001",
 		"dct:source": "http://www.qudt.org/qudt/owl/1.0.0/unit/Instances.html#GigaHertz"
 	},
 	{
 		"@id": "iot:TeraHertz",
 		"@type": "iot:LineFrequencyUnit",
-		"rdfs:comment": "The unit of line frequency, expressed in a unit prefix meaning "one trillion".",
-		"rdfs:label": "terahertz",
+		"rdfs:comment": "The unit of line frequency, expressed in a unit prefix meaning 'one trillion'.",
+		"rdfs:label": "THz",
 		"iot:reference": "0112/2///62720#UAA287#001"
 	},	
 	{
@@ -487,71 +487,71 @@
 		"@id": "iot:Volt",
 		"@type": "iot:VoltageUnit",
 		"rdfs:comment": "The unit of voltage.",
-		"rdfs:label": "volt",
+		"rdfs:label": "V",
 		"iot:reference": "0112/2///62720#UAA296#001",
 		"dct:source": "http://www.qudt.org/qudt/owl/1.0.0/unit/Instances.html#Volt"
 	},
 	{
 		"@id": "iot:FemtoVolt",
 		"@type": "iot:VoltageUnit",
-		"rdfs:comment": "The unit of voltage, expressed in a unit prefix meaning "one 0.000000000000001".",
-		"rdfs:label": "femtovolt",
+		"rdfs:comment": "The unit of voltage, expressed in a unit prefix meaning 'one 0.000000000000001'.",
+		"rdfs:label": "fV",
 		"iot:reference": "0112/2///62720#UAC770#001"
 	},
 	{
 		"@id": "iot:PicoVolt",
 		"@type": "iot:VoltageUnit",
-		"rdfs:comment": "The unit of voltage, expressed in a unit prefix meaning "one trillionth".",
-		"rdfs:label": "picovolt",
+		"rdfs:comment": "The unit of voltage, expressed in a unit prefix meaning 'one trillionth'.",
+		"rdfs:label": "pV",
 		"iot:reference": "0112/2///62720#UAB363#001"
 	},
 	{
 		"@id": "iot:NanoVolt",
 		"@type": "iot:VoltageUnit",
-		"rdfs:comment": "The unit of voltage, expressed in a unit prefix meaning "one billionth".",
-		"rdfs:label": "nanovolt",
+		"rdfs:comment": "The unit of voltage, expressed in a unit prefix meaning 'one billionth'.",
+		"rdfs:label": "nV",
 		"iot:reference": "0112/2///62720#UAC771#001"
 	},
 	{
 		"@id": "iot:MicroVolt",
 		"@type": "iot:VoltageUnit",
-		"rdfs:comment": "The unit of voltage, expressed in a unit prefix meaning "one millionth".",
-		"rdfs:label": "microvolt",
+		"rdfs:comment": "The unit of voltage, expressed in a unit prefix meaning 'one millionth'.",
+		"rdfs:label": "µV",
 		"iot:reference": "0112/2///62720#UAA078#001"
 	},
 	{
 		"@id": "iot:MilliVolt",
 		"@type": "iot:VoltageUnit",
-		"rdfs:comment": "The unit of voltage, expressed in a unit prefix meaning "one thousandth".",
-		"rdfs:label": "millivolt",
+		"rdfs:comment": "The unit of voltage, expressed in a unit prefix meaning 'one thousandth'.",
+		"rdfs:label": "mV",
 		"iot:reference": "0112/2///62720#UAA804#001"
 	},
 	{
 		"@id": "iot:KiloVolt",
 		"@type": "iot:VoltageUnit",
-		"rdfs:comment": "The unit of voltage, expressed in a unit prefix meaning "one thousand".",
-		"rdfs:label": "kilovolt",
+		"rdfs:comment": "The unit of voltage, expressed in a unit prefix meaning 'one thousand'.",
+		"rdfs:label": "kV",
 		"iot:reference": "0112/2///62720#UAA580#001"
 	},
 	{
 		"@id": "iot:MegaVolt",
 		"@type": "iot:VoltageUnit",
-		"rdfs:comment": "The unit of voltage, expressed in a unit prefix meaning "one million".",
-		"rdfs:label": "megavolt",
+		"rdfs:comment": "The unit of voltage, expressed in a unit prefix meaning 'one million'.",
+		"rdfs:label": "MV",
 		"iot:reference": "0112/2///62720#UAA221#001"
 	},
 	{
 		"@id": "iot:GigaVolt",
 		"@type": "iot:VoltageUnit",
-		"rdfs:comment": "The unit of voltage, expressed in a unit prefix meaning "one billion".",
-		"rdfs:label": "gigavolt",
+		"rdfs:comment": "The unit of voltage, expressed in a unit prefix meaning 'one billion'.",
+		"rdfs:label": "GV",
 		"iot:reference": "0112/2///62720#UAC772#001"
 	},
 	{
 		"@id": "iot:TeraVolt",
 		"@type": "iot:VoltageUnit",
-		"rdfs:comment": "The unit of voltage, expressed in a unit prefix meaning "one trillion".",
-		"rdfs:label": "teravolt",
+		"rdfs:comment": "The unit of voltage, expressed in a unit prefix meaning 'one trillion'.",
+		"rdfs:label": "TV",
 		"iot:reference": "0112/2///62720#UAC773#001"
 	},	
 	{
@@ -606,7 +606,7 @@
 		"@id": "iot:WattHour",
 		"@type": "iot:ActiveEnergyUnit",
 		"rdfs:comment": "The unit of the active enregy.",
-		"rdfs:label": "watt-hour",
+		"rdfs:label": "W·h",
 		"dct:source": "http://www.qudt.org/qudt/owl/1.0.0/unit/Instances.html#Watthour",
 		"iot:reference": "0112/2///62720#UAA308#001"
 	},
@@ -614,7 +614,7 @@
 		"@id": "iot:KiloWattHour",
 		"@type": "iot:ActiveEnergyUnit",
 		"rdfs:comment": "The unit of the active enregy, expressed in kilo (one thousand) as a decimal unit prefix.",
-		"rdfs:label": "kilowatt-hour",
+		"rdfs:label": "kW·h",
 		"dct:source": "http://www.qudt.org/qudt/owl/1.0.0/unit/Instances.html#Kilowatthour",
 		"iot:reference": "0112/2///62720#UAA584#001"
 	},
@@ -622,21 +622,21 @@
 		"@id": "iot:MegaWattHour",
 		"@type": "iot:ActiveEnergyUnit",
 		"rdfs:comment": "The unit of the active enregy, expressed in mega (one million) as a decimal unit prefix.",
-		"rdfs:label": "megawatt-hour",
+		"rdfs:label": "MW·h",
 		"iot:reference": "0112/2///62720#UAA225#001"
 	},
 	{
 		"@id": "iot:GigaWattHour",
 		"@type": "iot:ActiveEnergyUnit",
 		"rdfs:comment": "The unit of the active enregy, expressed in giga (one billion) as a decimal unit prefix.",
-		"rdfs:label": "gigawatt-hour",
+		"rdfs:label": "GW·h",
 		"iot:reference": "0112/2///62720#UAA155#001"
 	},
 	{
 		"@id": "iot:TeraWattHour",
 		"@type": "iot:ActiveEnergyUnit",
 		"rdfs:comment": "The unit of the active enregy, expressed in giga (one trillion) as a decimal unit prefix.",
-		"rdfs:label": "terawatt-hour",
+		"rdfs:label": "TW·h",
 		"iot:reference": "0112/2///62720#UAA155#001"
 	},
 	{
@@ -652,33 +652,33 @@
 		"@id": "iot:VoltAmpereReactiveHour",
 		"@type": "iot:ReactiveEnergyUnit",
 		"rdfs:comment": "The unit of reactive enregy.",
-		"rdfs:label": "volt-ampere-reactive-hour"
+		"rdfs:label": "var·h"
 	},
 	{
 		"@id": "iot:KiloVoltAmpereReactiveHour",
 		"@type": "iot:ReactiveEnergyUnit",
 		"rdfs:comment": "The unit of reactive enregy, expressed in kilo (one thousand) as a decimal unit prefix.",
-		"rdfs:label": "kilovolt-ampere-reactive-hour",
+		"rdfs:label": "kvar·h",
 		"iot:reference": "0112/2///62720#UAB195#001"
 	},
 	{
 		"@id": "iot:MegaVoltAmpereReactiveHour",
 		"@type": "iot:ReactiveEnergyUnit",
 		"rdfs:comment": "The unit of reactive enregy, expressed in mega (one million) as a decimal unit prefix.",
-		"rdfs:label": "megavolt-ampere-reactive-hour",
+		"rdfs:label": "Mvar·h",
 		"iot:reference": "0112/2///62720#UAB198#001"
 	},
 	{
 		"@id": "iot:GigaVoltAmpereReactiveHour",
 		"@type": "iot:ReactiveEnergyUnit",
 		"rdfs:comment": "The unit of reactive enregy, expressed in giga (one billion) as a decimal unit prefix.",
-		"rdfs:label": "gigavolt-ampere-reactive-hour"
+		"rdfs:label": "Gvar·h"
 	},
 	{
 		"@id": "iot:TeraVoltAmpereReactiveHour",
 		"@type": "iot:ReactiveEnergyUnit",
 		"rdfs:comment": "The unit of the reactive enregy, expressed in giga (one trillion) as a decimal unit prefix.",
-		"rdfs:label": "teravolt-ampere-reactive-hour"
+		"rdfs:label": "Tvar·h"
 	}
   ]
 }


### PR DESCRIPTION
Corrected JSON-LD syntax issue in core, capability and unit files. 
Added short names for all the units except VoltAmpereHours, KiloVoltAmpereHours, MegaVoltAmpereHours, GigaVoltAmpereHours, TeraVoltAmpereHours.
The short names are added by referring to IEC 61360 - Common Data Dictionary Standard.