### PR TITLE
Use camelCase for carbonDioxideConcentration

### DIFF
--- a/capability.jsonld
+++ b/capability.jsonld
@@ -1497,7 +1497,7 @@
     ]
   },
   {
-    "@id": "iot:carbonDioxideconcentration",
+    "@id": "iot:carbonDioxideConcentration",
     "@type": [
       "rdf:Property"
     ],
@@ -1508,7 +1508,7 @@
     ],
     "rdfs:label": [
       {
-        "@value": "carbonDioxideconcentration"
+        "@value": "carbonDioxideConcentration"
       }
     ],
     "rdfs:subPropertyOf": [


### PR DESCRIPTION
To keep naming consistent, I think the property should be `carbonDioxideConcentration` instead of `carbonDioxideconcentration` (notice concentration starting on a lower C).

((Sorry for the newline at the end of the file. The GitHub editor added that.))